### PR TITLE
Implement hybrid AI router

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1399,11 +1399,13 @@ dependencies = [
 name = "gsteng"
 version = "0.1.0"
 dependencies = [
+ "once_cell",
  "reqwest",
  "serde",
  "serde_json",
  "tauri",
  "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -4172,6 +4174,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -8,4 +8,6 @@ tauri = { version = "1", features = ["api-all"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-reqwest = { version = "0.11", features = ["json", "blocking"] }
+reqwest = { version = "0.11", features = ["json", "blocking", "stream"] }
+once_cell = "1"
+tokio-stream = "0.1"

--- a/src-tauri/src/ai/cloud_llm.rs
+++ b/src-tauri/src/ai/cloud_llm.rs
@@ -1,5 +1,108 @@
-// Placeholder for cloud LLM integration (OpenAI/Anthropic)
+use std::env;
+use std::time::Duration;
+
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use tokio_stream::StreamExt;
+
+/// Structures used to communicate with the OpenAI API
+#[derive(Serialize)]
+struct ChatRequest<'a> {
+    model: &'a str,
+    messages: Vec<Message<'a>>,
+    stream: bool,
+}
+
+#[derive(Serialize)]
+struct Message<'a> {
+    role: &'a str,
+    content: &'a str,
+}
+
+#[derive(Deserialize)]
+struct ChatChunk {
+    choices: Vec<Choice>,
+}
+
+#[derive(Deserialize)]
+struct Choice {
+    delta: Delta,
+}
+
+#[derive(Deserialize)]
+struct Delta {
+    content: Option<String>,
+}
+
+/// Generate a response from the OpenAI API. The function internally uses
+/// streaming responses but returns the aggregated result as a `String`.
 pub async fn generate_response(prompt: &str) -> String {
-    // A real implementation would call external APIs
-    format!("Cloud LLM response to: {}", prompt)
+    let key = match env::var("OPENAI_API_KEY") {
+        Ok(k) => k,
+        Err(_) => return "OpenAI API key not set".into(),
+    };
+
+    let client = match Client::builder().timeout(Duration::from_secs(30)).build() {
+        Ok(c) => c,
+        Err(e) => return format!("Failed to build HTTP client: {e}"),
+    };
+
+    let request = ChatRequest {
+        model: "gpt-3.5-turbo",
+        messages: vec![Message {
+            role: "user",
+            content: prompt,
+        }],
+        stream: true,
+    };
+
+    let url = "https://api.openai.com/v1/chat/completions";
+    // simple retry logic
+    for _ in 0..3 {
+        match client
+            .post(url)
+            .bearer_auth(&key)
+            .json(&request)
+            .send()
+            .await
+        {
+            Ok(response) => {
+                if !response.status().is_success() {
+                    continue;
+                }
+                let mut stream = response.bytes_stream();
+                let mut out = String::new();
+                while let Some(item) = stream.next().await {
+                    match item {
+                        Ok(bytes) => {
+                            for line in bytes.split(|&b| b == b'\n') {
+                                let line = match line.strip_prefix(b"data: ") {
+                                    Some(l) => l,
+                                    None => continue,
+                                };
+                                if line == b"[DONE]" {
+                                    return out;
+                                }
+                                if let Ok(chunk) = serde_json::from_slice::<ChatChunk>(line) {
+                                    if let Some(content) =
+                                        chunk.choices.get(0).and_then(|c| c.delta.content.clone())
+                                    {
+                                        out.push_str(&content);
+                                    }
+                                }
+                            }
+                        }
+                        Err(_) => return "Failed to read stream".into(),
+                    }
+                }
+                return out;
+            }
+            Err(_) => {
+                // wait a bit before retrying
+                tokio::time::sleep(Duration::from_millis(500)).await;
+            }
+        }
+    }
+
+    "Failed to contact OpenAI".into()
 }

--- a/src-tauri/src/ai/local_llm.rs
+++ b/src-tauri/src/ai/local_llm.rs
@@ -1,4 +1,111 @@
-// Placeholder for local LLM integration using Ollama
-pub fn generate_response(prompt: &str) -> String {
-    format!("Local LLM response to: {}", prompt)
+use std::time::Duration;
+
+use once_cell::sync::Lazy;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
+use tokio_stream::StreamExt;
+
+use super::cloud_llm;
+
+static CURRENT_MODEL: Lazy<RwLock<String>> = Lazy::new(|| RwLock::new("llama2".to_string()));
+
+#[derive(Serialize)]
+struct GenerateRequest<'a> {
+    model: &'a str,
+    prompt: &'a str,
+    stream: bool,
+}
+
+#[derive(Deserialize)]
+struct GenerateChunk {
+    response: Option<String>,
+    done: bool,
+}
+
+/// Attempt to generate a response from the local Ollama instance. If the call
+/// fails, the function falls back to the cloud model.
+pub async fn generate_response(prompt: &str) -> String {
+    let model = { CURRENT_MODEL.read().await.clone() };
+    match generate_with_model(&model, prompt).await {
+        Ok(r) => r,
+        Err(_) => cloud_llm::generate_response(prompt).await,
+    }
+}
+
+async fn generate_with_model(model: &str, prompt: &str) -> Result<String, reqwest::Error> {
+    let client = Client::builder().timeout(Duration::from_secs(30)).build()?;
+    let req = GenerateRequest {
+        model,
+        prompt,
+        stream: true,
+    };
+    let resp = client
+        .post("http://localhost:11434/api/generate")
+        .json(&req)
+        .send()
+        .await?;
+
+    if !resp.status().is_success() {
+        return Err(reqwest::Error::new(
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+            "ollama",
+        ));
+    }
+
+    let mut stream = resp.bytes_stream();
+    let mut out = String::new();
+    while let Some(chunk) = stream.next().await {
+        let bytes = chunk?;
+        for line in bytes.split(|&b| b == b'\n') {
+            if line.is_empty() {
+                continue;
+            }
+            if let Ok(data) = serde_json::from_slice::<GenerateChunk>(line) {
+                if let Some(content) = data.response {
+                    out.push_str(&content);
+                }
+                if data.done {
+                    return Ok(out);
+                }
+            }
+        }
+    }
+    Ok(out)
+}
+
+#[derive(Deserialize)]
+struct ModelTags {
+    models: Vec<ModelInfo>,
+}
+
+#[derive(Deserialize)]
+struct ModelInfo {
+    name: String,
+}
+
+/// Download a model using Ollama's pull API
+pub async fn download_model(model: &str) -> Result<(), reqwest::Error> {
+    let client = Client::new();
+    let body = serde_json::json!({ "name": model });
+    client
+        .post("http://localhost:11434/api/pull")
+        .json(&body)
+        .send()
+        .await?;
+    Ok(())
+}
+
+/// Retrieve the list of locally available models
+pub async fn list_models() -> Result<Vec<String>, reqwest::Error> {
+    let client = Client::new();
+    let resp = client.get("http://localhost:11434/api/tags").send().await?;
+    let list: ModelTags = resp.json().await?;
+    Ok(list.models.into_iter().map(|m| m.name).collect())
+}
+
+/// Switch the active model for future requests
+pub async fn switch_model(model: &str) -> Result<(), reqwest::Error> {
+    *CURRENT_MODEL.write().await = model.to_string();
+    Ok(())
 }

--- a/src-tauri/src/ai/router.rs
+++ b/src-tauri/src/ai/router.rs
@@ -1,13 +1,62 @@
+use std::collections::HashMap;
+use std::env;
+use std::time::Duration;
+
+use once_cell::sync::Lazy;
+use tokio::sync::RwLock;
+
 use super::{cloud_llm, local_llm};
+
+/// Simple in-memory cache for prompts and their responses
+static CACHE: Lazy<RwLock<HashMap<String, String>>> = Lazy::new(|| RwLock::new(HashMap::new()));
 
 pub enum LlmSource {
     Local,
     Cloud,
 }
 
+fn network_available() -> bool {
+    reqwest::blocking::Client::new()
+        .get("https://www.google.com")
+        .timeout(Duration::from_secs(2))
+        .send()
+        .is_ok()
+}
+
+fn query_complexity(prompt: &str) -> usize {
+    prompt.split_whitespace().count()
+}
+
+/// Route the prompt to either the local or cloud model based on heuristics.
 pub async fn get_response(source: LlmSource, prompt: &str) -> String {
-    match source {
-        LlmSource::Local => local_llm::generate_response(prompt),
-        LlmSource::Cloud => cloud_llm::generate_response(prompt).await,
+    // Check cache first
+    if let Some(cached) = CACHE.read().await.get(prompt).cloned() {
+        return cached;
     }
+
+    // Determine which source to use
+    let mut chosen = source;
+
+    if env::var("AI_PRIVACY_LOCAL_ONLY").ok().as_deref() == Some("1") {
+        chosen = LlmSource::Local;
+    }
+
+    if !network_available() {
+        chosen = LlmSource::Local;
+    }
+
+    if query_complexity(prompt) > 50 {
+        chosen = LlmSource::Cloud;
+    }
+
+    let result = match chosen {
+        LlmSource::Local => local_llm::generate_response(prompt).await,
+        LlmSource::Cloud => cloud_llm::generate_response(prompt).await,
+    };
+
+    CACHE
+        .write()
+        .await
+        .insert(prompt.to_string(), result.clone());
+    result
 }


### PR DESCRIPTION
## Summary
- add streaming OpenAI integration in `cloud_llm`
- connect to local Ollama models with fallbacks and model management
- route intelligently between cloud and local with caching
- add `once_cell` and `tokio-stream` deps

## Testing
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: javascriptcoregtk-4.0.pc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68731c7ac9e88333a8d5e39f4ba3cc6d