### PR TITLE
Add robotics hardware abstraction and telemetry modules

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -11,3 +11,6 @@ serde_json = "1"
 reqwest = { version = "0.11", features = ["json", "blocking", "stream"] }
 once_cell = "1"
 tokio-stream = "0.1"
+async-trait = "0.1"
+tokio-tungstenite = { version = "0.20", features = ["rustls-tls-native-roots"] }
+futures-util = "0.3"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3,6 +3,7 @@
 mod ai;
 mod voice;
 mod code_analysis;
+mod robotics;
 mod commands;
 
 fn main() {

--- a/src-tauri/src/robotics/hardware_interface.rs
+++ b/src-tauri/src/robotics/hardware_interface.rs
@@ -1,0 +1,42 @@
+//! Hardware abstraction traits for robotics components.
+
+use async_trait::async_trait;
+
+/// Communication channel used to talk to hardware devices.
+/// Serial represents a tty path while Network uses a socket address.
+#[derive(Clone, Debug)]
+pub enum CommunicationBus {
+    Serial(String),
+    Network(String),
+}
+
+/// Common functionality for low level motor controllers.
+#[async_trait]
+pub trait MotorController {
+    async fn set_speed(&self, id: u8, speed: f32) -> Result<(), String>;
+    async fn stop(&self, id: u8) -> Result<(), String>;
+}
+
+/// Control interface for standard servos.
+#[async_trait]
+pub trait ServoControl {
+    async fn set_position(&self, id: u8, position: f32) -> Result<(), String>;
+    async fn set_speed(&self, id: u8, speed: f32) -> Result<(), String>;
+    async fn set_torque(&self, id: u8, torque: f32) -> Result<(), String>;
+}
+
+/// Sensors available on the robot.
+#[async_trait]
+pub trait SensorReader {
+    async fn read_imu(&self) -> Result<(f32, f32, f32), String>;
+    async fn read_distance(&self) -> Result<f32, String>;
+    async fn capture_image(&self) -> Result<Vec<u8>, String>;
+}
+
+/// Power management interface.
+#[async_trait]
+pub trait PowerManager {
+    async fn battery_level(&self) -> Result<f32, String>;
+    async fn shutdown(&self) -> Result<(), String>;
+}
+

--- a/src-tauri/src/robotics/mobility_controller.rs
+++ b/src-tauri/src/robotics/mobility_controller.rs
@@ -1,0 +1,97 @@
+//! High level movement primitives for the robot.
+
+use tokio::time::{sleep, Duration};
+
+use super::hardware_interface::{MotorController, ServoControl};
+
+/// Different mobility configurations the robot can operate in.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum MobilityMode {
+    Wheeled,
+    Walking,
+}
+
+/// Controller that exposes simple motion commands.
+pub struct MobilityController<I>
+where
+    I: MotorController + ServoControl + Send + Sync,
+{
+    interface: I,
+    mode: MobilityMode,
+    max_speed: f32,
+    max_joint_angle: f32,
+}
+
+impl<I> MobilityController<I>
+where
+    I: MotorController + ServoControl + Send + Sync,
+{
+    pub fn new(interface: I) -> Self {
+        Self {
+            interface,
+            mode: MobilityMode::Wheeled,
+            max_speed: 1.0,
+            max_joint_angle: 1.57,
+        }
+    }
+
+    /// Change the mobility mode of the robot.
+    pub fn set_mode(&mut self, mode: MobilityMode) {
+        self.mode = mode;
+    }
+
+    /// Drive forward in wheeled mode.
+    pub async fn forward(&self, speed: f32) -> Result<(), String> {
+        self.ensure_wheeled()?;
+        let clamped = speed.clamp(-self.max_speed, self.max_speed);
+        self.interface.set_speed(0, clamped).await
+    }
+
+    /// Drive backward in wheeled mode.
+    pub async fn backward(&self, speed: f32) -> Result<(), String> {
+        self.forward(-speed).await
+    }
+
+    /// Rotate the robot in place.
+    pub async fn rotate(&self, speed: f32) -> Result<(), String> {
+        self.ensure_wheeled()?;
+        let clamped = speed.clamp(-self.max_speed, self.max_speed);
+        self.interface.set_speed(1, clamped).await
+    }
+
+    /// Control leg joints when in walking mode.
+    pub async fn set_joints(&self, joints: &[f32]) -> Result<(), String> {
+        self.ensure_walking()?;
+        for (i, pos) in joints.iter().enumerate() {
+            let angle = pos.clamp(-self.max_joint_angle, self.max_joint_angle);
+            self.interface.set_position(i as u8, angle).await?;
+        }
+        Ok(())
+    }
+
+    /// Simple motion planning placeholder.
+    pub async fn smooth_move(&self, target: f32, duration_ms: u64) -> Result<(), String> {
+        let steps = 10;
+        let step = target / steps as f32;
+        for i in 0..steps {
+            self.forward(step * i as f32).await?;
+            sleep(Duration::from_millis(duration_ms / steps)).await;
+        }
+        Ok(())
+    }
+
+    fn ensure_wheeled(&self) -> Result<(), String> {
+        if self.mode != MobilityMode::Wheeled {
+            return Err("Not in wheeled mode".into());
+        }
+        Ok(())
+    }
+
+    fn ensure_walking(&self) -> Result<(), String> {
+        if self.mode != MobilityMode::Walking {
+            return Err("Not in walking mode".into());
+        }
+        Ok(())
+    }
+}
+

--- a/src-tauri/src/robotics/mod.rs
+++ b/src-tauri/src/robotics/mod.rs
@@ -1,0 +1,3 @@
+pub mod hardware_interface;
+pub mod mobility_controller;
+pub mod telemetry;

--- a/src-tauri/src/robotics/telemetry.rs
+++ b/src-tauri/src/robotics/telemetry.rs
@@ -1,0 +1,61 @@
+//! Telemetry system for broadcasting robot state.
+
+use std::sync::Arc;
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::{broadcast, Mutex};
+use futures_util::{StreamExt, SinkExt};
+use tokio_tungstenite::tungstenite::Message;
+
+/// Container for telemetry operations.
+pub struct Telemetry {
+    tx: broadcast::Sender<String>,
+    log: Arc<Mutex<Vec<String>>>,
+}
+
+impl Telemetry {
+    pub fn new() -> Self {
+        let (tx, _) = broadcast::channel(16);
+        Self { tx, log: Arc::new(Mutex::new(Vec::new())) }
+    }
+
+    /// Start the WebSocket server used by the dashboard.
+    pub async fn start_server(&self, addr: &str) -> Result<(), String> {
+        let listener = TcpListener::bind(addr).await.map_err(|e| e.to_string())?;
+        while let Ok((stream, _)) = listener.accept().await {
+            let tx = self.tx.clone();
+            let log = self.log.clone();
+            tokio::spawn(handle_connection(stream, tx, log));
+        }
+        Ok(())
+    }
+
+    /// Broadcast new telemetry data to listeners and log it.
+    pub async fn broadcast(&self, data: String) {
+        let _ = self.tx.send(data.clone());
+        self.log.lock().await.push(data);
+    }
+
+    /// Replay logged data to a subscriber.
+    pub async fn replay(&self) -> Vec<String> {
+        self.log.lock().await.clone()
+    }
+}
+
+async fn handle_connection(stream: TcpStream, tx: broadcast::Sender<String>, log: Arc<Mutex<Vec<String>>>) {
+    if let Ok(ws_stream) = tokio_tungstenite::accept_async(stream).await {
+        let (mut write, mut read) = ws_stream.split();
+        let mut rx = tx.subscribe();
+        // send historical data first
+        for entry in log.lock().await.iter() {
+            let _ = write.send(Message::Text(entry.clone())).await;
+        }
+        tokio::spawn(async move {
+            while let Ok(msg) = rx.recv().await {
+                let _ = write.send(Message::Text(msg)).await;
+            }
+        });
+        // consume incoming messages, ignore them
+        while let Some(Ok(_)) = read.next().await {}
+    }
+}
+


### PR DESCRIPTION
## Summary
- define robotics hardware traits (motor, servo, sensors, power)
- add mobility controller with wheeled and walking mode primitives
- implement telemetry broadcasting with WebSocket server
- register new robotics module in main backend
- add async-trait and tokio-tungstenite dependencies

## Testing
- `cargo check --manifest-path src-tauri/Cargo.toml --no-default-features` *(fails: javascriptcoregtk-4.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68732cfa6c8c8333a90b85e8e58632db