### PR TITLE
Add config and state manager modules

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -737,6 +737,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+
+[[package]]
 name = "deranged"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1025,6 +1031,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1399,6 +1414,10 @@ dependencies = [
 name = "gsteng"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
+ "base64 0.21.7",
+ "futures-util",
+ "notify",
  "once_cell",
  "reqwest",
  "serde",
@@ -1406,6 +1425,8 @@ dependencies = [
  "tauri",
  "tokio",
  "tokio-stream",
+ "tokio-tungstenite",
+ "toml 0.8.23",
 ]
 
 [[package]]
@@ -1838,6 +1859,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1955,6 +1996,26 @@ dependencies = [
  "fluent-uri",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -2146,6 +2207,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
@@ -2245,6 +2318,25 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.9.1",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio 0.8.11",
+ "walkdir",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3167,6 +3259,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3208,12 +3314,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -3281,6 +3421,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "security-framework"
@@ -3461,6 +3611,17 @@ checksum = "d98238b800e0d1576d8b6e3de32827c2d74bee68bb97748dcf5071fb53965432"
 dependencies = [
  "nodrop",
  "stable_deref_trait",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -4146,7 +4307,7 @@ dependencies = [
  "bytes",
  "io-uring",
  "libc",
- "mio",
+ "mio 1.0.4",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -4178,6 +4339,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4186,6 +4357,21 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite",
 ]
 
 [[package]]
@@ -4252,8 +4438,15 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
+ "toml_write",
  "winnow 0.7.12",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower-service"
@@ -4342,6 +4535,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "rustls",
+ "sha1",
+ "thiserror 1.0.69",
+ "url",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4369,6 +4582,12 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -14,3 +14,6 @@ tokio-stream = "0.1"
 async-trait = "0.1"
 tokio-tungstenite = { version = "0.20", features = ["rustls-tls-native-roots"] }
 futures-util = "0.3"
+toml = "0.8"
+notify = "6"
+base64 = "0.21"

--- a/src-tauri/src/config/config.rs
+++ b/src-tauri/src/config/config.rs
@@ -1,0 +1,191 @@
+use serde::{Deserialize, Serialize};
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+use notify::{RecommendedWatcher, RecursiveMode, Watcher, EventKind};
+use tokio::sync::Mutex;
+
+const ENCRYPTION_KEY: &[u8] = b"gsteng-secret";
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct AiConfig {
+    #[serde(default = "AiConfig::default_model")]
+    pub preferred_model: String,
+    #[serde(default)]
+    pub use_cloud: bool,
+}
+
+impl AiConfig {
+    fn default_model() -> String {
+        "local".into()
+    }
+}
+
+impl Default for AiConfig {
+    fn default() -> Self {
+        Self { preferred_model: Self::default_model(), use_cloud: false }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct ApiKeys {
+    pub openai: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct HardwareProfile {
+    #[serde(default = "HardwareProfile::default_port")]
+    pub port: String,
+    #[serde(default = "HardwareProfile::default_baud")]
+    pub baud_rate: u32,
+}
+
+impl HardwareProfile {
+    fn default_port() -> String {
+        "/dev/ttyUSB0".into()
+    }
+    fn default_baud() -> u32 {
+        115200
+    }
+}
+
+impl Default for HardwareProfile {
+    fn default() -> Self {
+        Self { port: Self::default_port(), baud_rate: Self::default_baud() }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Personality {
+    #[serde(default = "Personality::default_name")]
+    pub name: String,
+    #[serde(default = "Personality::default_greeting")]
+    pub greeting: String,
+}
+
+impl Personality {
+    fn default_name() -> String {
+        "TARS".into()
+    }
+    fn default_greeting() -> String {
+        "Hello".into()
+    }
+}
+
+impl Default for Personality {
+    fn default() -> Self {
+        Self { name: Self::default_name(), greeting: Self::default_greeting() }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Config {
+    #[serde(default)]
+    pub ai: AiConfig,
+    #[serde(default)]
+    pub api_keys: ApiKeys,
+    #[serde(default)]
+    pub hardware: HardwareProfile,
+    #[serde(default)]
+    pub personality: Personality,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self { ai: AiConfig::default(), api_keys: ApiKeys::default(), hardware: HardwareProfile::default(), personality: Personality::default() }
+    }
+}
+
+pub type SharedConfig = Arc<Mutex<Config>>;
+
+impl Config {
+    pub fn load<P: AsRef<Path>>(path: P) -> io::Result<Self> {
+        if path.as_ref().exists() {
+            let content = fs::read_to_string(&path)?;
+            let mut cfg: Config = toml::from_str(&content).map_err(to_io)?;
+            cfg.decrypt_keys();
+            cfg.validate();
+            Ok(cfg)
+        } else {
+            let cfg = Config::default();
+            cfg.save(&path)?;
+            Ok(cfg)
+        }
+    }
+
+    pub fn save<P: AsRef<Path>>(&self, path: P) -> io::Result<()> {
+        let mut enc = self.clone();
+        enc.encrypt_keys();
+        let toml = toml::to_string_pretty(&enc).map_err(to_io)?;
+        fs::write(path, toml)
+    }
+
+    fn validate(&mut self) {
+        if self.ai.preferred_model.is_empty() {
+            self.ai.preferred_model = AiConfig::default_model();
+        }
+        if self.hardware.port.is_empty() {
+            self.hardware.port = HardwareProfile::default_port();
+        }
+        if self.hardware.baud_rate == 0 {
+            self.hardware.baud_rate = HardwareProfile::default_baud();
+        }
+        if self.personality.name.is_empty() {
+            self.personality.name = Personality::default_name();
+        }
+        if self.personality.greeting.is_empty() {
+            self.personality.greeting = Personality::default_greeting();
+        }
+    }
+
+    fn encrypt_keys(&mut self) {
+        if let Some(ref mut key) = self.api_keys.openai {
+            *key = encrypt(key);
+        }
+    }
+
+    fn decrypt_keys(&mut self) {
+        if let Some(ref mut key) = self.api_keys.openai {
+            *key = decrypt(key);
+        }
+    }
+}
+
+fn to_io<E: std::fmt::Display>(e: E) -> io::Error {
+    io::Error::new(io::ErrorKind::Other, e.to_string())
+}
+
+fn cipher(data: &[u8]) -> Vec<u8> {
+    data.iter()
+        .enumerate()
+        .map(|(i, b)| b ^ ENCRYPTION_KEY[i % ENCRYPTION_KEY.len()])
+        .collect()
+}
+
+fn encrypt(text: &str) -> String {
+    base64::encode(cipher(text.as_bytes()))
+}
+
+fn decrypt(text: &str) -> String {
+    match base64::decode(text) {
+        Ok(bytes) => String::from_utf8_lossy(&cipher(&bytes)).into(),
+        Err(_) => String::new(),
+    }
+}
+
+pub fn start_hot_reload(path: PathBuf, cfg: SharedConfig) -> notify::Result<RecommendedWatcher> {
+    let mut watcher = notify::recommended_watcher(move |res| {
+        if let Ok(event) = res {
+            if matches!(event.kind, EventKind::Modify(_)) || matches!(event.kind, EventKind::Create(_)) {
+                if let Ok(new_cfg) = Config::load(&path) {
+                    let mut lock = cfg.blocking_lock();
+                    *lock = new_cfg;
+                }
+            }
+        }
+    })?;
+    watcher.watch(&path, RecursiveMode::NonRecursive)?;
+    Ok(watcher)
+}

--- a/src-tauri/src/config/mod.rs
+++ b/src-tauri/src/config/mod.rs
@@ -1,0 +1,2 @@
+pub mod config;
+pub mod state_manager;

--- a/src-tauri/src/config/state_manager.rs
+++ b/src-tauri/src/config/state_manager.rs
@@ -1,0 +1,72 @@
+use std::{cmp::Ordering, collections::BinaryHeap, sync::Arc};
+use tokio::sync::{broadcast, Mutex};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RobotState {
+    Idle,
+    Listening,
+    Thinking,
+    Moving,
+}
+
+#[derive(Debug, Eq)]
+pub struct Command {
+    pub priority: u8,
+    pub action: String,
+}
+
+impl Ord for Command {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.priority.cmp(&other.priority)
+    }
+}
+
+impl PartialOrd for Command {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for Command {
+    fn eq(&self, other: &Self) -> bool {
+        self.priority == other.priority && self.action == other.action
+    }
+}
+
+pub struct StateManager {
+    state: Arc<Mutex<RobotState>>,
+    queue: Arc<Mutex<BinaryHeap<Command>>>,
+    event_tx: broadcast::Sender<RobotState>,
+}
+
+impl StateManager {
+    pub fn new() -> Self {
+        let (tx, _) = broadcast::channel(16);
+        Self {
+            state: Arc::new(Mutex::new(RobotState::Idle)),
+            queue: Arc::new(Mutex::new(BinaryHeap::new())),
+            event_tx: tx,
+        }
+    }
+
+    pub fn subscribe(&self) -> broadcast::Receiver<RobotState> {
+        self.event_tx.subscribe()
+    }
+
+    pub async fn current_state(&self) -> RobotState {
+        *self.state.lock().await
+    }
+
+    pub async fn set_state(&self, new: RobotState) {
+        *self.state.lock().await = new;
+        let _ = self.event_tx.send(new);
+    }
+
+    pub async fn enqueue_command(&self, cmd: Command) {
+        self.queue.lock().await.push(cmd);
+    }
+
+    pub async fn next_command(&self) -> Option<Command> {
+        self.queue.lock().await.pop()
+    }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -5,9 +5,25 @@ mod voice;
 mod code_analysis;
 mod robotics;
 mod commands;
+mod config;
+
+use config::config::{start_hot_reload, Config, SharedConfig};
+use config::state_manager::StateManager;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::sync::Mutex;
 
 fn main() {
+    let config_path = PathBuf::from("config.toml");
+    let cfg = Config::load(&config_path).expect("load config");
+    let shared_cfg: SharedConfig = Arc::new(Mutex::new(cfg));
+    let _watcher = start_hot_reload(config_path, shared_cfg.clone()).expect("watch config");
+
+    let state_manager = StateManager::new();
+
     tauri::Builder::default()
+        .manage(shared_cfg)
+        .manage(state_manager)
         .invoke_handler(tauri::generate_handler![commands::ask_ai])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");


### PR DESCRIPTION
## Summary
- add config system with TOML, encryption and hot reload
- manage robot state with global state manager
- wire new modules into `main.rs`
- add dependencies for config features

## Testing
- `npm test` *(fails: Missing script)*
- `cargo check` *(fails: system library `gdk-3.0` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68732fb8b5b88333b88560b6087cd831