### PR TITLE
Add interactive TARS interface and telemetry components

### DIFF
--- a/src/components/TARSInterface.tsx
+++ b/src/components/TARSInterface.tsx
@@ -1,0 +1,111 @@
+import React, { useState } from 'react';
+import styled from '@emotion/styled';
+import Panel from './common/Panel';
+import Button from './common/Button';
+
+const Wrapper = styled(Panel)`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const TARSBody = styled.div`
+  width: 60px;
+  height: 150px;
+  background: rgba(255, 255, 255, 0.1);
+  position: relative;
+  transform-style: preserve-3d;
+  animation: rotate 8s linear infinite;
+
+  @keyframes rotate {
+    from {
+      transform: rotateY(0deg);
+    }
+    to {
+      transform: rotateY(360deg);
+    }
+  }
+`;
+
+const SliderRow = styled.div`
+  display: flex;
+  width: 100%;
+  justify-content: space-between;
+  margin-top: 0.5rem;
+`;
+
+const Indicator = styled.div<{ active: boolean }>`
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: ${({ active }) => (active ? 'var(--color-primary)' : '#444')};
+  margin-left: 0.5rem;
+`;
+
+const Status = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  margin-top: 0.5rem;
+  font-size: 0.9rem;
+`;
+
+const StatusItem = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const TARSInterface: React.FC = () => {
+  const [humor, setHumor] = useState(50);
+  const [honesty, setHonesty] = useState(90);
+  const [voiceActive, setVoiceActive] = useState(false);
+
+  return (
+    <Wrapper>
+      <TARSBody />
+      <SliderRow>
+        <label>
+          Humor
+          <input
+            type="range"
+            min={0}
+            max={100}
+            value={humor}
+            onChange={(e) => setHumor(Number(e.target.value))}
+          />
+        </label>
+        <label>
+          Honesty
+          <input
+            type="range"
+            min={0}
+            max={100}
+            value={honesty}
+            onChange={(e) => setHonesty(Number(e.target.value))}
+          />
+        </label>
+      </SliderRow>
+      <div style={{ display: 'flex', alignItems: 'center', marginTop: '0.5rem' }}>
+        Voice Activity
+        <Indicator active={voiceActive} />
+        <Button onClick={() => setVoiceActive((v) => !v)} style={{ marginLeft: '1rem' }}>
+          Toggle
+        </Button>
+      </div>
+      <Status>
+        <StatusItem>
+          <span>Battery:</span> <span>100%</span>
+        </StatusItem>
+        <StatusItem>
+          <span>Connection:</span> <span>Connected</span>
+        </StatusItem>
+        <StatusItem>
+          <span>Mode:</span> <span>Normal</span>
+        </StatusItem>
+      </Status>
+    </Wrapper>
+  );
+};
+
+export default TARSInterface;
+

--- a/src/components/Telemetry/index.tsx
+++ b/src/components/Telemetry/index.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import Panel from '../common/Panel';
+import Button from '../common/Button';
+
+const Dashboard = styled(Panel)`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+`;
+
+const Pose3D = styled.div`
+  height: 200px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.05);
+  margin-bottom: 1rem;
+`;
+
+const SensorGrid = styled.div`
+  flex: 1;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.5rem;
+`;
+
+const SensorGraph = styled.div`
+  background: rgba(255, 255, 255, 0.05);
+  height: 100px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const Controls = styled.div`
+  display: flex;
+  justify-content: space-around;
+  margin-top: 0.5rem;
+`;
+
+const Telemetry: React.FC = () => {
+  return (
+    <Dashboard>
+      <Pose3D>3D Pose Placeholder</Pose3D>
+      <SensorGrid>
+        <SensorGraph>Sensor 1</SensorGraph>
+        <SensorGraph>Sensor 2</SensorGraph>
+        <SensorGraph>Sensor 3</SensorGraph>
+        <SensorGraph>Sensor 4</SensorGraph>
+      </SensorGrid>
+      <Controls>
+        <Button>Forward</Button>
+        <Button>Stop</Button>
+        <Button>Backward</Button>
+      </Controls>
+    </Dashboard>
+  );
+};
+
+export default Telemetry;
+

--- a/src/components/Voice/index.tsx
+++ b/src/components/Voice/index.tsx
@@ -1,7 +1,97 @@
-import React from 'react';
+import React, { useState } from 'react';
+import styled from '@emotion/styled';
+import Button from '../common/Button';
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const Waveform = styled.div<{ active: boolean }>`
+  height: 20px;
+  margin-top: 0.5rem;
+  background: var(--color-primary);
+  opacity: ${({ active }) => (active ? 1 : 0.2)};
+  transition: opacity 0.3s;
+`;
+
+const HistoryList = styled.ul`
+  list-style: none;
+  padding: 0;
+  margin: 0.5rem 0 0 0;
+`;
 
 const VoiceControls: React.FC = () => {
-  return <div>Voice Controls Placeholder</div>;
+  const [mode, setMode] = useState<'push' | 'continuous'>('push');
+  const [listening, setListening] = useState(false);
+  const [transcript, setTranscript] = useState('');
+  const [confidence, setConfidence] = useState(0);
+  const [history, setHistory] = useState<{ text: string; confidence: number }[]>(
+    []
+  );
+
+  const toggleMode = () => setMode((m) => (m === 'push' ? 'continuous' : 'push'));
+
+  const startListening = () => {
+    setListening(true);
+    // placeholder transcription
+    setTimeout(() => {
+      const text = 'Example command';
+      const conf = 0.95;
+      setTranscript(text);
+      setConfidence(conf);
+    }, 1000);
+  };
+
+  const stopListening = () => {
+    setListening(false);
+    if (transcript) {
+      setHistory([...history, { text: transcript, confidence }]);
+      setTranscript('');
+      setConfidence(0);
+    }
+  };
+
+  return (
+    <Wrapper>
+      <div style={{ display: 'flex', alignItems: 'center' }}>
+        <span>Mode: {mode === 'push' ? 'Push-to-talk' : 'Continuous'}</span>
+        <Button onClick={toggleMode} style={{ marginLeft: '0.5rem' }}>
+          Toggle Mode
+        </Button>
+      </div>
+      <div style={{ marginTop: '0.5rem' }}>
+        {mode === 'push' ? (
+          <Button
+            onMouseDown={startListening}
+            onMouseUp={stopListening}
+            onTouchStart={startListening}
+            onTouchEnd={stopListening}
+          >
+            Hold to Talk
+          </Button>
+        ) : (
+          <Button onClick={listening ? stopListening : startListening}>
+            {listening ? 'Stop Listening' : 'Start Listening'}
+          </Button>
+        )}
+      </div>
+      <Waveform active={listening} />
+      {transcript && (
+        <div style={{ marginTop: '0.5rem' }}>
+          "{transcript}" ({Math.round(confidence * 100)}%)
+        </div>
+      )}
+      <HistoryList>
+        {history.map((h, i) => (
+          <li key={i}>
+            {h.text} ({Math.round(h.confidence * 100)}%)
+          </li>
+        ))}
+      </HistoryList>
+    </Wrapper>
+  );
 };
 
 export default VoiceControls;
+


### PR DESCRIPTION
## Summary
- add animated `TARSInterface` with sliders and status display
- implement voice control modes and history
- add telemetry dashboard placeholder

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68744dbc10448333a7926e6bcce69d55