### PR TITLE
Add safety system and extend backend commands

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,8 +1,87 @@
-use tauri::command;
 use crate::ai::{router, router::LlmSource};
+use crate::config::config::SharedConfig;
+use crate::config::state_manager::{RobotState, StateManager};
+use crate::robotics::telemetry::Telemetry;
+use crate::safety::SharedSafety;
+use std::sync::Arc;
+use tauri::command;
 
 #[command]
 pub async fn ask_ai(prompt: String, use_cloud: bool) -> String {
-    let source = if use_cloud { LlmSource::Cloud } else { LlmSource::Local };
+    let source = if use_cloud {
+        LlmSource::Cloud
+    } else {
+        LlmSource::Local
+    };
     router::get_response(source, &prompt).await
+}
+
+#[command]
+pub async fn set_personality(
+    humor: f32,
+    honesty: f32,
+    sarcasm: f32,
+    cfg: tauri::State<'_, SharedConfig>,
+) -> Result<(), String> {
+    let mut lock = cfg.lock().await;
+    lock.personality.humor = humor.clamp(0.0, 1.0);
+    lock.personality.honesty = honesty.clamp(0.0, 1.0);
+    lock.personality.sarcasm = sarcasm.clamp(0.0, 1.0);
+    Ok(())
+}
+
+#[command]
+pub async fn start_listening(state: tauri::State<'_, StateManager>) {
+    state.set_state(RobotState::Listening).await;
+}
+
+#[command]
+pub async fn stop_listening(state: tauri::State<'_, StateManager>) {
+    state.set_state(RobotState::Idle).await;
+}
+
+#[command]
+pub async fn move_robot(
+    command: String,
+    telemetry: tauri::State<'_, Arc<Telemetry>>,
+    safety: tauri::State<'_, SharedSafety>,
+    state: tauri::State<'_, StateManager>,
+) -> Result<(), String> {
+    if safety.is_emergency().await {
+        return Err("Emergency stop engaged".into());
+    }
+    if !safety.check_move_allowed().await {
+        return Err("Rate limited".into());
+    }
+
+    if let Some(rest) = command.strip_prefix("servo:") {
+        for part in rest.split(',') {
+            let val: f32 = part.trim().parse().map_err(|_| "invalid servo value")?;
+            if !safety.check_servo_bounds(val) {
+                return Err("servo position out of bounds".into());
+            }
+        }
+    }
+
+    telemetry.broadcast(format!("move:{command}")).await;
+    state.set_state(RobotState::Moving).await;
+    safety.feed_watchdog().await;
+    state.set_state(RobotState::Idle).await;
+    Ok(())
+}
+
+#[command]
+pub async fn get_telemetry(telemetry: tauri::State<'_, Arc<Telemetry>>) -> Vec<String> {
+    telemetry.replay().await
+}
+
+#[command]
+pub async fn emergency_stop(
+    telemetry: tauri::State<'_, Arc<Telemetry>>,
+    safety: tauri::State<'_, SharedSafety>,
+    state: tauri::State<'_, StateManager>,
+) {
+    safety.trigger_emergency().await;
+    telemetry.broadcast("emergency_stop".into()).await;
+    state.set_state(RobotState::Idle).await;
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,14 +1,20 @@
-#![cfg_attr(all(not(debug_assertions), target_os = "windows"), windows_subsystem = "windows")]
+#![cfg_attr(
+    all(not(debug_assertions), target_os = "windows"),
+    windows_subsystem = "windows"
+)]
 
 mod ai;
-mod voice;
 mod code_analysis;
-mod robotics;
 mod commands;
 mod config;
+mod robotics;
+mod safety;
+mod voice;
 
 use config::config::{start_hot_reload, Config, SharedConfig};
 use config::state_manager::StateManager;
+use robotics::telemetry::Telemetry;
+use safety::{start_watchdog, Safety};
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -20,11 +26,30 @@ fn main() {
     let _watcher = start_hot_reload(config_path, shared_cfg.clone()).expect("watch config");
 
     let state_manager = StateManager::new();
+    let telemetry = Arc::new(Telemetry::new());
+    let safety = Safety::new();
 
     tauri::Builder::default()
         .manage(shared_cfg)
         .manage(state_manager)
-        .invoke_handler(tauri::generate_handler![commands::ask_ai])
+        .manage(telemetry.clone())
+        .manage(safety.clone())
+        .invoke_handler(tauri::generate_handler![
+            commands::ask_ai,
+            commands::set_personality,
+            commands::start_listening,
+            commands::stop_listening,
+            commands::move_robot,
+            commands::get_telemetry,
+            commands::emergency_stop,
+        ])
+        .setup(move |_| {
+            start_watchdog(safety.clone());
+            tauri::async_runtime::spawn(async move {
+                let _ = telemetry.start_server("127.0.0.1:9000").await;
+            });
+            Ok(())
+        })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src-tauri/src/safety.rs
+++ b/src-tauri/src/safety.rs
@@ -1,0 +1,69 @@
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::Mutex;
+
+#[derive(Clone)]
+pub struct Safety {
+    last_move: Arc<Mutex<Instant>>,
+    last_watchdog: Arc<Mutex<Instant>>,
+    emergency: Arc<Mutex<bool>>,
+    pub rate_limit: Duration,
+    pub servo_min: f32,
+    pub servo_max: f32,
+    pub connection_timeout: Duration,
+}
+
+pub type SharedSafety = Arc<Safety>;
+
+impl Safety {
+    pub fn new() -> SharedSafety {
+        Arc::new(Safety {
+            last_move: Arc::new(Mutex::new(Instant::now())),
+            last_watchdog: Arc::new(Mutex::new(Instant::now())),
+            emergency: Arc::new(Mutex::new(false)),
+            rate_limit: Duration::from_millis(100),
+            servo_min: -1.57,
+            servo_max: 1.57,
+            connection_timeout: Duration::from_secs(3),
+        })
+    }
+
+    pub async fn check_move_allowed(&self) -> bool {
+        let mut last = self.last_move.lock().await;
+        let now = Instant::now();
+        if now.duration_since(*last) >= self.rate_limit {
+            *last = now;
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn check_servo_bounds(&self, pos: f32) -> bool {
+        pos >= self.servo_min && pos <= self.servo_max
+    }
+
+    pub async fn trigger_emergency(&self) {
+        *self.emergency.lock().await = true;
+    }
+
+    pub async fn is_emergency(&self) -> bool {
+        *self.emergency.lock().await
+    }
+
+    pub async fn feed_watchdog(&self) {
+        *self.last_watchdog.lock().await = Instant::now();
+    }
+}
+
+pub fn start_watchdog(safety: SharedSafety) {
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(safety.connection_timeout).await;
+            let last = *safety.last_watchdog.lock().await;
+            if Instant::now().duration_since(last) > safety.connection_timeout {
+                safety.trigger_emergency().await;
+            }
+        }
+    });
+}


### PR DESCRIPTION
## Summary
- expand personality fields in config
- implement a new Safety module
- expose several robot control commands
- wire new commands, safety and telemetry in main

## Testing
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: javascriptcoregtk-4.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_687452224380833392b82e0c77c72e36